### PR TITLE
Remove call to plist_options as it is deprecated

### DIFF
--- a/autoraise.rb
+++ b/autoraise.rb
@@ -26,8 +26,6 @@ class Autoraise < Formula
     bin.install "AutoRaise"
   end
 
-  plist_options :manual => "AutoRaise"
-
   def plist
     <<~EOS
       <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Fixes the following warning:

> Warning: Calling plist_options is deprecated! Use service.require_root instead.
> Please report this issue to the dimentium/autoraise tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
>   /opt/homebrew/Library/Taps/dimentium/homebrew-autoraise/autoraise.rb:29

The only consequence of just removing the call to plist_options appears to be that, during installation, the following hint is not printed anymore:

> Or, if you don't want/need a background service you can just run:
>   AutoRaise