### PR TITLE
Set service name properly

### DIFF
--- a/autoraise.rb
+++ b/autoraise.rb
@@ -49,6 +49,10 @@ class Autoraise < Formula
     EOS
   end
 
+  service do
+    name macos: "#{plist_name}"
+  end
+
   test do
     system "false"
   end


### PR DESCRIPTION
Explicit set service name following the Homebrew [formula cookbook](https://docs.brew.sh/Formula-Cookbook#service-files). Fixes #9.